### PR TITLE
Avoid uncommenting Serial.print statements to calibrate sensors

### DIFF
--- a/ab412_head_switch_controller/ab412_head_switch_controller.ino
+++ b/ab412_head_switch_controller/ab412_head_switch_controller.ino
@@ -4,6 +4,9 @@
 //SECOND ROW: 1st PIN6,PIN7 etc
 
 #include <Wire.h>
+
+//#define DEBUG
+
 uint16_t x,y;
 uint8_t b = 0b00000000; //digital pins 0 to 7; x ^= (1 << n); - toggles nth bit of x.  all other bits left alone.
 uint8_t b1 = 0b00000000; //digital pins 8 to 15
@@ -16,18 +19,20 @@ byte data[2];
 void setup() {
   Wire.begin(13);                // join i2c bus with address #8
   Wire.onRequest(requestEvent); // register event
- // Serial.begin(9600);           // start serial for output
+  #if defined(DEBUG)
+    Serial.begin(9600);           // start serial for output
+  #endif
   for (int i = 0; i <= pins; i++)
   {
     pinMode(i, INPUT_PULLUP);
   }
-  
+
 }
 
-void loop() 
+void loop()
 {
 
-  
+
   for (int i = 0; i <= pins; i++)
   {
     bool pin = !digitalRead(i);
@@ -61,16 +66,17 @@ void loop()
         b2 &= ~(1 <<  (i - 16));
       }
     }
-    
-// DEBUG
-//    printBits(b);
-//    Serial.print(" ");
-//    printBits(b1);
-//    Serial.print(" ");
-//    printBits(b2);
-//    Serial.println();
- } 
-  
+
+    #if defined(DEBUG)
+      printBits(b);
+      Serial.print(" ");
+      printBits(b1);
+      Serial.print(" ");
+      printBits(b2);
+      Serial.println();
+    #endif
+ }
+
 }
 
 void requestEvent() {
@@ -88,4 +94,3 @@ void printBits(byte myByte){
        Serial.print('0');
  }
 }
-

--- a/cyclic/cyclic.ino
+++ b/cyclic/cyclic.ino
@@ -12,6 +12,9 @@
 
 #include <Wire.h>
 #include <Adafruit_ADS1015.h>
+
+//#define DEBUG
+
 Adafruit_ADS1115 ads1115;
 int16_t x,y;
 
@@ -21,20 +24,24 @@ byte data[4];
 void setup() {
   //Wire.begin(10);                // join i2c bus with address #8
  // Wire.onRequest(requestEvent); // register event
-//  Serial.begin(9600);           // start serial for output
+  //#if defined(DEBUG)
+    //Serial.begin(9600);           // start serial for output
+  //#endif
  // ads1115.begin();
   //ads1115.setGain(GAIN_ONE);
-  
+
 }
 
-void loop() 
-{  
+void loop()
+{
  // x = ads1115.readADC_SingleEnded(0) >> 3;
  // y = ads1115.readADC_SingleEnded(1) >> 3;
 
-  
-//Serial.println(x);
-//Serial.println(y);
+
+#if defined(DEBUG)
+  //Serial.println(x);
+  //Serial.println(y);
+#endif
 }
 
 // function that executes whenever data is received from master

--- a/i2c_peripheral/i2c_peripheral.ino
+++ b/i2c_peripheral/i2c_peripheral.ino
@@ -11,6 +11,9 @@
 
 
 #include <Wire.h>
+
+//#define DEBUG
+
 uint16_t x,y;
 uint8_t b = 0b00000000; //digital pins 2 to 9; x ^= (1 << n); - toggles nth bit of x.  all other bits left alone.
 byte pins[] = {2};
@@ -21,12 +24,15 @@ byte data[5];
 void setup() {
   Wire.begin(8);                // join i2c bus with address #8
   Wire.onRequest(requestEvent); // register event
-  Serial.begin(9600);           // start serial for output
+  #if defined(DEBUG)
+    Serial.begin(9600);           // start serial for output
+  #endif
+
   for (int i = 0; i < sizeof(pins); i++)
   {
     pinMode(pins[i], INPUT_PULLUP);
   }
-  
+
 }
 
 void loop() {
@@ -43,13 +49,16 @@ void loop() {
     {
       b &= ~(1 << i);      // forces ith bit of b to be 0.  all other bits left alone.
     }
-    
-    //Serial.println(b);
-    
+
+    #if defined(DEBUG)
+      Serial.println(b);
+    #endif
   }
-  
-//Serial.println(x);
-//Serial.println(y);
+
+  #if defined(DEBUG)
+    Serial.println(x);
+    Serial.println(y);
+  #endif
 }
 
 // function that executes whenever data is received from master

--- a/simple_collective/simple_collective.ino
+++ b/simple_collective/simple_collective.ino
@@ -11,26 +11,31 @@
 
 
 #include <Wire.h>
+
+//#define CALIBRATE
+
 uint16_t z,rz;
 byte data[4];
 
 uint8_t filter_counter_z = 6;
 uint8_t filter_counter_rz = 6;
 
-void setup() 
+void setup()
 {
   pinMode(10, OUTPUT);           // power up the pot board
   digitalWrite(10, HIGH);
   Wire.begin(10);                // join i2c bus with address #8
   Wire.onRequest(requestEvent); // register event
-//  Serial.begin(9600);           // start serial for output
+  #if defined(CALIBRATE)
+    Serial.begin(9600);           // start serial for output
+  #endif
 }
 
-void loop() 
+void loop()
 {
   z = filteredRead(A0,filter_counter_z);
   rz = filteredRead(A1,filter_counter_rz);
-  // uncomment Serial.print statements and change 2nd and 3rd values to physical min and max
+  // uncomment #define CALIBRATE statement and change 2nd and 3rd values to physical min and max
   // of your lever; change the order of 2 last values to invert an axis
   z = map(z,1002,18,0,1023);
   rz = map(rz,10,976,1023,0);
@@ -54,10 +59,12 @@ void loop()
   {
     rz = 0;
   }
-  
-//Serial.print(z); 
-//Serial.print(" ");
-//Serial.println(rz);
+
+  #if defined(CALIBRATE)
+    Serial.print(z);
+    Serial.print(" ");
+    Serial.println(rz);
+  #endif
 }
 
 // function that executes whenever data is received from master
@@ -75,12 +82,12 @@ uint16_t filteredRead (uint16_t input,uint8_t filter_counter)
   uint32_t filter = 0;
   for (uint8_t i=0;i<filter_counter;i++)
   {
-    
+
       filter+= analogRead(input);
-      delay(1); 
+      delay(1);
   }
 
   uint16_t val = filter/filter_counter;
   return val;
-  
+
 }

--- a/single_engine_collective/single_engine_collective.ino
+++ b/single_engine_collective/single_engine_collective.ino
@@ -11,38 +11,43 @@
 
 
 #include <Wire.h>
+
+//#define CALIBRATE
+
 uint16_t z,rz;
 byte data[4];
 
 uint8_t filter_counter_z = 6;
 uint8_t filter_counter_rz = 6;
 
-void setup() 
+void setup()
 {
   pinMode(10, OUTPUT);           // power up the pot board
   digitalWrite(10, HIGH);
   Wire.begin(12);                // join i2c bus with address #11
   Wire.onRequest(requestEvent); // register event
-//  Serial.begin(9600);           // start serial for output
+  #if defined(CALIBRATE)
+    Serial.begin(9600);           // start serial for output
+  #endif
 }
 
-void loop() 
+void loop()
 {
   z = filteredRead(A0,filter_counter_z);
   rz = filteredRead(A1,filter_counter_rz);
   // we have 200 degree turn instead of 300, so a little adjustment is necessary
-  // uncomment Serial.print statements and change 2nd and 3rd values to physical min and max
+  // uncomment #define CALIBRATE statement and change 2nd and 3rd values to physical min and max
   // of your lever
 
-  
+
   z = map(z,14,1003,1023,0);
   rz = map(rz,0,992,1023,0);
-//
-//  Serial.print(z); 
-//  Serial.print(" ");
-//  Serial.println(rz);
-  
 
+  #if defined(CALIBRATE)
+    Serial.print(z);
+    Serial.print(" ");
+    Serial.println(rz);
+  #endif
 }
 
 // function that executes whenever data is received from master
@@ -59,12 +64,12 @@ uint16_t filteredRead (uint16_t input,uint8_t filter_counter)
 {
   uint32_t filter = 0;
   for (uint8_t i=0;i<filter_counter;i++)
-  {  
+  {
       filter+= analogRead(input);
-      delay(1); 
+      delay(1);
   }
 
   uint16_t val = filter/filter_counter;
   return val;
-  
+
 }

--- a/twin_engine_collective/twin_engine_collective.ino
+++ b/twin_engine_collective/twin_engine_collective.ino
@@ -1,4 +1,7 @@
 #include <Wire.h>
+
+//#define CALIBRATE
+
 uint16_t z,rz,ry;
 byte data[6];
 
@@ -6,36 +9,38 @@ uint8_t filter_counter_z = 6;
 uint8_t filter_counter_rz = 6;
 uint8_t filter_counter_ry = 6;
 
-void setup() 
+void setup()
 {
   Wire.begin(15);                // join i2c bus with address #11
   Wire.onRequest(requestEvent); // register event
- // Serial.begin(9600);           // start serial for output
+  #if defined(CALIBRATE)
+    Serial.begin(9600);           // start serial for output
+  #endif
 }
 
-void loop() 
+void loop()
 {
   // read axis, invert if needed
   z = filteredRead(A0,filter_counter_z);
   rz = filteredRead(A1,filter_counter_rz);
   ry = filteredRead(A2,filter_counter_ry);
   // we have 200 degree turn instead of 300, so a little adjustment is necessary
-  // uncomment Serial.print statements and change 2nd and 3rd values to physical min and max
-  // of your lever
+  // uncomment #define CALIBRATE statement and change 2nd and 3rd values to physical min and max
+  // of your lever.
+  // You can swap 2 last numbers to invert the axis if needed
+  #if !defined(CALIBRATE)
+    z = map(z,0,1002,1023,0);
+    rz = map(rz,125,1023,1023,0);
+    ry = map(ry,114,1023,1023,0);
+  #endif
 
-// comment this to calibrate cyclic, then uncomment Serial.prints below and enter min and max values as 2 and 3 numbers
-// you can swap 2 last numbers to invert the axis if needed
-  z = map(z,0,1002,1023,0);
-  rz = map(rz,125,1023,1023,0);
-  ry = map(ry,114,1023,1023,0);
-//
-//  Serial.print(z); 
-//  Serial.print(" ");
-//  Serial.print(rz);
-//  Serial.print(" ");
-//  Serial.println(ry);
-//  
-
+  #if defined(CALIBRATE)
+    Serial.print(z);
+    Serial.print(" ");
+    Serial.print(rz);
+    Serial.print(" ");
+    Serial.println(ry);
+  #endif
 }
 
 // function that executes whenever data is received from master
@@ -60,14 +65,14 @@ uint16_t filteredRead (uint16_t input,uint8_t filter_counter)
 {
   uint32_t filter = 0;
   for (uint8_t i=0;i<filter_counter;i++)
-  {  
+  {
       filter+= analogRead(input);
-      delay(1); 
+      delay(1);
   }
 
   uint16_t val = filter/filter_counter;
   return val;
-  
+
 }
 
 int invert (int val)
@@ -75,4 +80,3 @@ int invert (int val)
   val = 1023 - val;
   return val;
 }
-

--- a/uh1_head/uh1_head.ino
+++ b/uh1_head/uh1_head.ino
@@ -5,6 +5,9 @@
 
 
 #include <Wire.h>
+
+//#define DEBUG
+
 uint8_t x,y;
 uint8_t b = 0b00000000; //digital pins 0 to 7; x ^= (1 << n); - toggles nth bit of x.  all other bits left alone.
 uint8_t b1 = 0b00000000; //digital pins 8 to 15
@@ -17,20 +20,23 @@ byte data[4];
 void setup() {
   Wire.begin(17);                // join i2c bus with address #8
   Wire.onRequest(requestEvent); // register event
-    //Serial.begin(9600);           // start serial for output
+  #if defined(DEBUG)
+    Serial.begin(9600);           // start serial for output
+  #endif
+
   for (int i = 0; i <= pins; i++)
   {
     pinMode(i, INPUT_PULLUP);
   }
-  
+
 }
 
-void loop() 
+void loop()
 {
-  x = analogRead(A0) >> 2; 
+  x = analogRead(A0) >> 2;
   y = analogRead(A1) >> 2;
 
-  
+
   for (int i = 0; i <= pins; i++)
   {
     bool pin = !digitalRead(i);
@@ -56,19 +62,18 @@ void loop()
         b1 &= ~(1 << (i - 8));
       }
     }
-    
-// DEBUG
-//    printBits(b);
-//    Serial.print(" ");
-//    printBits(b1);
-//    Serial.print(" ");
-//    Serial.print(x);
-//    Serial.print(" ");
-//    Serial.print(y);
-//    Serial.println();
-    
+
+    #if defined(DEBUG)
+      printBits(b);
+      Serial.print(" ");
+      printBits(b1);
+      Serial.print(" ");
+      Serial.print(x);
+      Serial.print(" ");
+      Serial.print(y);
+      Serial.println();
+    #endif
  }
-  
 }
 
 void requestEvent() {
@@ -87,4 +92,3 @@ void printBits(byte myByte){
        Serial.print('0');
  }
 }
-


### PR DESCRIPTION
First of all congratulations for your great work. This project will bring happiness to a lot of flight simmers, enthusiast of helicopter flying. I would like to contribute a bit by helping with the code, trying to improve usability, modularization, mainteinability and readiness of this wonderful code.

Currently, to calibrate a sensor, a comment in the code says that the user has to uncomment several Serial.print statements. Also, it's not said in the code comments, but the user also has to remember to uncomment the Serial.begin statement, in setup().

With the help of C/C++'s preprocessor there's a easier way to achieve this. Just by commenting/uncommenting a #define, the preprocessor can insert (or not) all the code related to calibration. I suggest this way for enabling/disabling the calibration Serial statements:

```
#define CALIBRATE  // insert at the top of the file, to be easily found by the user

void setup() {
    [...]
    #if defined(CALIBRATE)
        Serial.begin(9600);
    #endif
}

void loop() {
    [...]
    #if defined(CALIBRATE)
        Serial.println(xxxxxxxx);
    #endif
}
```

The user only has to:
- Comment #define CALIBRATE --> disables Serial messages
- Uncomment #define CALIBRATE  -->  enables Serial Messages

The same schema can be used for debugging messages. #define DEBUG can be inserted at the beginning of the file and then, just check insert the Serial statements into a #if defined(DEBUG) ... #endif block. 

