### PR TITLE
Redesigned B8 stick device code.

### DIFF
--- a/b8_stick/b8_stick.ino
+++ b/b8_stick/b8_stick.ino
@@ -21,6 +21,8 @@
 
 #include <Wire.h>
 
+//#define GRIP_TEST
+
 #define B8STICK_I2C_ADDRESS 20
 
 #define POT_BOARD_BUTTON_PIN  2
@@ -31,15 +33,20 @@
 #define PTT_BUTTON_PIN        7
 
 #define INTERCOM_PRESS_DURATION 130  // adjust to your liking, values below 100 are not recommended
-unsigned long intercom_press_time = 0;
+unsigned long intercom_press_ts = 0;
 
 uint8_t pot_x_value;     // hat potentiometer X axis reading
 uint8_t pot_y_value;     // hat potentiometer Y axis reading
 uint8_t buttons = 0x00;  // bit array with the state of the buttons connected
                          // to digital pins 2 to 7 (0 = released, 1 = pressed)
+uint8_t buf = 0x00;    
+bool ptt_press = 0;
 
 void setup()
 {
+  #if (defined GRIP_TEST)
+    Serial.begin(9600);
+  #endif
   Wire.begin(B8STICK_I2C_ADDRESS);
   Wire.onRequest(requestEvent);
 
@@ -57,8 +64,8 @@ void setup()
    * input, writing a 0 to bits 2..7 of DDRD register. Then the output is put
    * to HIGH to enable pullup resistors, writing a 1 to 2..7 bits of PORTD register.
    */
-  DDRD &= ~0b11111100;  // set pins 2..7 of port D as inputs, writing a 0 in the corresponding bits
-  PORTD |= 0b11111100;  // activate pullup resistors of 2..7 pins, writing a 1 in the corresponding bits
+  DDRD &= ~0b11111110;  // set pins 2..7 of port D as inputs, writing a 0 in the corresponding bits
+  PORTD |= 0b11111110;  // activate pullup resistors of 2..7 pins, writing a 1 in the corresponding bits
 }
 
 void loop()
@@ -82,19 +89,54 @@ void loop()
    * be transmitted by I2C (which is 0 based).
    */
   buttons = ~PIND >> 2;
+  buf = buttons; // we need some processing done over INTERCOM and PTT buttons, so this is needed to avoid sending raw values
+  buf &= ~(1 << (INTERCOM_BUTTON_PIN - 2)); // intercom button is always depressed by default
 
   /*
    * The trigger has two positions: half-press (intercom) and full-press
    * with a click (radio push to talk). When the trigger is fully pressed,
    * a half-press button is disabled by the software, so your sim will see
    * these two positions as entirely separate buttons.
+   * 
+   * We will only press intercom when we are sure we actually want it, because some games
+   * will only detect the 1st button press and for some reason will ignore the second one,
+   * e.g. ARMA3.
    */
-  if (buttons & (1 << (PTT_BUTTON_PIN - 2))) {
-    buttons &= ~(1 << (INTERCOM_BUTTON_PIN - 2));  // release INTERCOM button
+
+  if (buttons & (1 << (INTERCOM_BUTTON_PIN - 2))) // intercom pressed
+  {
+    if (ptt_press == 0) // PTT has not been pressed yet
+    {
+      if (intercom_press_ts == 0) // if we are pressing INTERCOM for the 1st time
+      {
+        intercom_press_ts = millis();
+      }
+      else
+      {
+        if ((millis() - intercom_press_ts) > INTERCOM_PRESS_DURATION) // if intercom is pressed for long enough we are sure we want it rather than PTT
+        {
+          if (!(buttons & (1 << (PTT_BUTTON_PIN - 2)))) // and the PTT button is not pressed
+          {
+            buf |= (1 << (INTERCOM_BUTTON_PIN - 2));  // press INTERCOM button
+          }
+          else
+          {
+            ptt_press = 1;
+          }
+        }
+      }
+    }
   }
-  else {
-    buttons |= (1 << (INTERCOM_BUTTON_PIN - 2));  // press INTERCOM button
+  else 
+  {
+    intercom_press_ts = 0;
+    ptt_press = 0;
   }
+
+  #if (defined GRIP_TEST)
+    printBits(buf);
+  #endif
+   
 }
 
 /**
@@ -110,10 +152,24 @@ void loop()
  *     - Bit 4: intercom button
  *     - Bit 5: ptt button
  */
-void requestEvent() {
+
+void printBits(byte myByte)
+{
+  for(byte mask = 0x80; mask; mask >>= 1)
+  {
+    if(mask  & myByte)
+        Serial.print('1');
+    else
+        Serial.print('0');
+  }
+  Serial.println();
+}
+ 
+void requestEvent() 
+{
   uint8_t data[3];
   data[0] = pot_x_value;
   data[1] = pot_y_value;
-  data[2] = buttons;
+  data[2] = buf;
   Wire.write(data, 3);
 }


### PR DESCRIPTION
This pull request redesigns completely the code of the B8 stick,
introducing the following changes:

- Define names for the pin numbers where each button is connected.

- Give meaning variable names to x and y values, in order to better
  document which is the axis of the pot that is read.

- Avoid iterating over all the button pins with a for loop to set
  the pins as input pullup. As all the buttons are connected to
  Arduino's digital pins 2 to 7, it means that they are connected
  to pins 2 to 7 of port D of the AVR microcontroller. Thus,
  instead of iterating, all the pin modes can be set with
  two single instructions.

- Following the previous point, all the button pins can be read
  with a single line of code, reading directly the PIND register.
  This is critical to reduce the latency of the device.

- Remove unneeded global variables.

- Format and document the code to improve readability
