### PR TITLE
Save RAM identifying connected devices.

### DIFF
--- a/master_controller/b_main.ino
+++ b/master_controller/b_main.ino
@@ -20,17 +20,23 @@ bool throttle_idle_cutoff[] = {1,1}; //we presume engines are off on startup
 
 
 bool b8stick_lastButtonState[] = {0, 0, 0, 0, 0, 0};
-bool dev_b8stick = 0;
-bool dev_cyclic = 0;
-bool dev_simple_collective = 0;
-bool dev_single_engine_collective = 0;
-bool dev_twin_engine_collective = 0;
-bool dev_pedals = 0;
-bool dev_cessna_engine_and_prop_controls = 0;
-bool dev_ab412_coll_head = 0;
-bool dev_huey_coll_head = 0;
-bool dev_throttle_quadrant = 0;
-bool dev_vrmax_panel = 0;
+
+enum Device: uint8_t {
+  DEVICE_B8_STICK,
+  DEVICE_CYCLIC,
+  DEVICE_SIMPLE_COLLECTIVE,
+  DEVICE_SINGLE_COLLECTIVE,
+  DEVICE_TWIN_COLLECTIVE,
+  DEVICE_PEDALS,
+  DEVICE_GA_CONTROLS,
+  DEVICE_THROTTLE_QUADRANT,
+  DEVICE_AB412_HEAD,
+  DEVICE_HUEY_HEAD,
+  DEVICE_VRMAX
+};
+
+uint16_t connected_devices = 0;
+
 bool SW_MODE_BUTTON = 0;
 bool SW_MODE_TOGGLE = 1;
 bool zero = 0;
@@ -111,7 +117,7 @@ bool dg_rate = 0;
 
 byte knob_button_hold_timeout = 100;
 
-enc_state e_state[7]; 
+enc_state e_state[7];
 byte MODE_SWITCH_BUTTON = 0;
 byte IDLE_STOP_BUTTON = 0;
 
@@ -148,49 +154,48 @@ void setup()
 void loop()
 {
   //Serial.println("WHEEE");
-  if (dev_b8stick == 1)
+  if (connected_devices | DEVICE_B8_STICK)
   {
     poll_b8stick();
   }
-  if (dev_cyclic == 1)
+  if (connected_devices | DEVICE_CYCLIC)
   {
     poll_cyclic();
   }
-  if (dev_simple_collective == 1)
+  if (connected_devices | DEVICE_SIMPLE_COLLECTIVE)
   {
     poll_simple_collective();
   }
-  if (dev_single_engine_collective == 1)
+  if (connected_devices | DEVICE_SINGLE_COLLECTIVE)
   {
     poll_single_engine_collective();
   }
-  if (dev_twin_engine_collective == 1)
+  if (connected_devices | DEVICE_TWIN_COLLECTIVE)
   {
     poll_twin_engine_collective();
   }
-  if (dev_pedals == 1)
+  if (connected_devices | DEVICE_PEDALS)
   {
     poll_pedals();
   }
-  if (dev_cessna_engine_and_prop_controls == 1)
+  if (connected_devices | DEVICE_GA_CONTROLS)
   {
     poll_cessna_engine_and_prop_controls();
   }
-  if (dev_ab412_coll_head == 1)
+  if (connected_devices | DEVICE_AB412_HEAD)
   {
     poll_ab412_coll_head();
   }
-  if (dev_vrmax_panel == 1)
+  if (connected_devices | DEVICE_VRMAX)
   {
     poll_vrmax_panel();
   }
-  if (dev_huey_coll_head == 1)
+  if (connected_devices | DEVICE_HUEY_HEAD)
   {
     poll_huey_coll_head();
   }
-  if (dev_throttle_quadrant == 1)
+  if (connected_devices | DEVICE_THROTTLE_QUADRANT)
   {
     poll_throttle_quadrant();
   }
 }
-

--- a/master_controller/c_flight_stick_gimbal.ino
+++ b/master_controller/c_flight_stick_gimbal.ino
@@ -10,7 +10,7 @@ void setup_cyclic()
     }
     simchair.setXAxisRange(0, ADC_RANGE);
     simchair.setYAxisRange(0, ADC_RANGE);
-    dev_cyclic = 1;
+    connected_devices |= (1 << DEVICE_CYCLIC);
     cyclic.begin();
     cyclic.setGain(GAIN_ONE);
   }

--- a/master_controller/d_b8stick.ino
+++ b/master_controller/d_b8stick.ino
@@ -6,7 +6,7 @@ void setup_b8stick()
 
   simchair_aux1.setXAxisRange(0, 255);
   simchair_aux1.setYAxisRange(0, 255);
-  dev_b8stick = 1;
+  connected_devices |= (1 << DEVICE_B8_STICK);
 }
 
 void poll_b8stick()

--- a/master_controller/e_single_collective.ino
+++ b/master_controller/e_single_collective.ino
@@ -5,7 +5,7 @@ void setup_single_engine_collective()
 
   simchair.setZAxisRange(SINGLE_COLLECTIVE_MIN, SINGLE_COLLECTIVE_MAX);
   simchair.setThrottleRange(SINGLE_COLLECTIVE_THR_MIN,SINGLE_COLLECTIVE_THR_MAX);//SINGLE_ENGINE_COLLECTIVE_IDLE_STOP_AXIS_VAL, 1023);
-  dev_single_engine_collective = 1;
+  connected_devices |= (1 << DEVICE_SINGLE_COLLECTIVE);
 }
 
 void set_idle_stop_latch_state(uint16_t throttle)

--- a/master_controller/f_twin_collective.ino
+++ b/master_controller/f_twin_collective.ino
@@ -6,7 +6,7 @@ void setup_twin_engine_collective()
   simchair.setZAxisRange(TWIN_COLLECTIVE_MIN, TWIN_COLLECTIVE_MAX);
   simchair.setThrottleRange(TWIN_COLLECTIVE_THR1_MIN,TWIN_COLLECTIVE_THR1_MAX);//SINGLE_ENGINE_COLLECTIVE_IDLE_STOP_AXIS_VAL, 1023);
   simchair.setRyAxisRange(TWIN_COLLECTIVE_THR2_MIN,TWIN_COLLECTIVE_THR2_MAX);
-  dev_twin_engine_collective = 1;
+  connected_devices |= (1 << DEVICE_TWIN_COLLECTIVE);
 }
 
 void poll_twin_engine_collective()

--- a/master_controller/g_helicopter_pedals.ino
+++ b/master_controller/g_helicopter_pedals.ino
@@ -16,7 +16,7 @@ void setup_pedals()
   {
     simchair.setRudderRange(0, ADC_RANGE);
   }
-  dev_pedals = 1;
+  connected_devices |= (1 << DEVICE_PEDALS);
   pedals.begin();
   pedals.setGain(GAIN_ONE);
 

--- a/master_controller/h_ab412_head.ino
+++ b/master_controller/h_ab412_head.ino
@@ -10,7 +10,7 @@ void setup_ab412_coll_head()
   simchair_aux2.setRyAxisRange(255, 0);
   simchair_aux2.setZAxisRange(0, 255);
   simchair_aux2.setRzAxisRange(0, 255);
-  dev_ab412_coll_head = 1;
+  connected_devices |= (1 << DEVICE_AB412_HEAD);
 
   for (byte i=0;i<32;i++)
   {

--- a/master_controller/i_huey_head.ino
+++ b/master_controller/i_huey_head.ino
@@ -6,7 +6,7 @@ void setup_huey_coll_head()
   COLLECTIVE_HOLD_BUTTON = HUEY_HEAD_COLLECTIVE_HOLD_BUTTON;
   simchair_aux2.setXAxisRange(0, 255);
   simchair_aux2.setYAxisRange(0, 255);
-  dev_huey_coll_head = 1;
+  connected_devices |= (1 << DEVICE_HUEY_HEAD);
   IDLE_STOP_BUTTON = huey_coll_head_idle_stop_buttons[0];
   for (byte i=0;i<32;i++)
   {

--- a/master_controller/j_ga_controls.ino
+++ b/master_controller/j_ga_controls.ino
@@ -6,7 +6,7 @@ void setup_cessna_engine_and_prop_controls()
   simchair_aux1.setRxAxisRange(0, 1023);
   simchair_aux1.setRyAxisRange(0, 1023);
   simchair_aux1.setThrottleRange(0, 1023);
-  dev_cessna_engine_and_prop_controls = 1;
+  connected_devices |= (1 << DEVICE_GA_CONTROLS);
 }
 
 

--- a/master_controller/k_simple_collective.ino
+++ b/master_controller/k_simple_collective.ino
@@ -5,7 +5,7 @@ void setup_simple_collective()
 
   simchair.setZAxisRange(SIMPLE_COLLECTIVE_MIN, SIMPLE_COLLECTIVE_MAX);
   simchair.setThrottleRange(SIMPLE_COLLECTIVE_THR_MIN, SIMPLE_COLLECTIVE_THR_MAX);
-  dev_simple_collective = 1;
+  connected_devices |= (1 << DEVICE_SIMPLE_COLLECTIVE);
 }
 
 void poll_simple_collective()

--- a/master_controller/l_throttle_quadrant.ino
+++ b/master_controller/l_throttle_quadrant.ino
@@ -10,7 +10,7 @@ void setup_throttle_quadrant()
   simchair_aux1.setRudderRange(THROTTLE_QUADRANT_SECONDARY_AXIS_TRESHOLD, THROTTLE_QUADRANT_PHYSICAL_AXIS_MAX);
   simchair_aux1.setZAxisRange(THROTTLE_QUADRANT_SECONDARY_AXIS_TRESHOLD, THROTTLE_QUADRANT_PHYSICAL_AXIS_MAX);
 
-  dev_throttle_quadrant = 1;
+  connected_devices |= (1 << DEVICE_THROTTLE_QUADRANT);
 }
 
 

--- a/master_controller/m_vrmax_panel.ino
+++ b/master_controller/m_vrmax_panel.ino
@@ -3,7 +3,7 @@ void setup_vrmax_panel()
   if (!is_device_connected(VRMAX_I2C_ADDRESS))
     return;
   byte b0,b1,b2;
-  dev_vrmax_panel = 1;
+  connected_devices |= (1 << DEVICE_VRMAX);
   read_bytes_from_vrmax_panel(&b0,&b1,&b2);
   for (byte i = 0; i < 7; i++)
   {
@@ -41,7 +41,7 @@ void read_bytes_from_vrmax_panel(byte* but0, byte* but1, byte* but2)
     byte b5 = Wire.read(); // encoder 4
 
     *but2 = b1;
-    
+
     e_state[3].val = b5;
     e_state[4].val = b3;
     e_state[5].val = b4;
@@ -72,7 +72,7 @@ void poll_vrmax_panel()
    else if ((e_state[i].last_val != e_state[i].val) && (e_state[i].press_counter == 0))
     {
       if ((e_diff > 1) && (e_diff < 100)) // fast left turn
-      {         
+      {
         set_button_mode_and_radio_switch_aware(i,1,0);
         e_state[i].enc_ts = millis();
         if (((obs_rate == 1) && (i == 4))|| ((i == 6) && (dg_rate == 1)))  // OBS knob
@@ -104,7 +104,7 @@ void poll_vrmax_panel()
         e_state[i].button_val = 1;
         e_state[i].last_val = e_state[i].val;
       }
-      
+
       else if ((e_diff <= 100) && (e_diff >= 1))// slow left turn
       {
         set_button_mode_and_radio_switch_aware(i,1,0);
@@ -133,8 +133,8 @@ void poll_vrmax_panel()
         set_button_mode_and_radio_switch_aware(i,1,e_state[i].last_dir);
         e_state[i].enc_ts = millis();
         e_state[i].press_counter--;
-        e_state[i].button_val = 1;   
-        e_state[i].last_val = e_state[i].val;    
+        e_state[i].button_val = 1;
+        e_state[i].last_val = e_state[i].val;
     }
   }
 
@@ -250,7 +250,7 @@ void set_button_mode_and_radio_switch_aware (byte i,bool val,byte dir)
         {
           simchair_aux1.setButton(radio_panel_knob_matrix[i].r2rpm1 - 1,val);
           e_state[i].button_id = (radio_panel_knob_matrix[i].r2rpm1 - 1);
-        }       
+        }
       }
 
     }
@@ -295,7 +295,7 @@ void set_button_mode_and_radio_switch_aware (byte i,bool val,byte dir)
         {
           simchair_aux1.setButton(radio_panel_knob_matrix[i].r2rpm2 - 1,val);
           e_state[i].button_id = (radio_panel_knob_matrix[i].r2rpm2 - 1);
-        }       
+        }
       }
     }
   }
@@ -556,7 +556,7 @@ void parse_radio_panel_switches (byte b, byte start_pos)
         {
          //Serial.println(obs_rate);
          obs_rate = !obs_rate;
-         
+
          e_state[4].press_counter = 0;
         }
         radio_matrix[i].sw_val = v;
@@ -570,7 +570,7 @@ void parse_radio_panel_switches (byte b, byte start_pos)
         {
          //Serial.println(obs_rate);
          dg_rate = !dg_rate;
-         
+
          e_state[6].press_counter = 0;
         }
         radio_matrix[i].sw_val = v;
@@ -589,7 +589,7 @@ void parse_radio_panel_switches (byte b, byte start_pos)
           {
             simchair_aux1.setButton(radio_panel_pb_matrix[0].c2f, v);
             radio_matrix[i].sw_val = v;
-          } 
+          }
           if (radio_device == 2)
           {
             simchair_aux1.setButton(radio_panel_pb_matrix[0].x1, v);
@@ -610,7 +610,7 @@ void parse_radio_panel_switches (byte b, byte start_pos)
           {
             simchair_aux1.setButton(radio_panel_pb_matrix[0].c2c, v);
             radio_matrix[i].sw_val = v;
-          } 
+          }
           if (radio_device == 2)
           {
             simchair_aux1.setButton(radio_panel_pb_matrix[0].x2, v);
@@ -631,7 +631,7 @@ void parse_radio_panel_switches (byte b, byte start_pos)
           {
             simchair_aux1.setButton(radio_panel_pb_matrix[0].n2f, v);
             radio_matrix[i].sw_val = v;
-          } 
+          }
           if (radio_device == 2)
           {
             simchair_aux1.setButton(radio_panel_pb_matrix[0].x3, v);
@@ -652,7 +652,7 @@ void parse_radio_panel_switches (byte b, byte start_pos)
           {
             simchair_aux1.setButton(radio_panel_pb_matrix[0].n2c, v);
             radio_matrix[i].sw_val = v;
-          } 
+          }
           if (radio_device == 2)
           {
             simchair_aux1.setButton(radio_panel_pb_matrix[0].x4, v);


### PR DESCRIPTION
In b_main.ino there are 11 boolean variables ("dev_*") created to store if
a devices are connected. Several bytes can be saved if a bit array is
used instead.

I have replaced the "dev_*" variables with a single 16 bits unsigned int
named "connected_devices". Each bit says if a device is connected (1) or
not (0). To identify the devices a new enum is created with entries in
the form "DEVICE_*".